### PR TITLE
Initialize graph service and update health endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -272,7 +272,7 @@ async def health():
     """
     サーバーの健康状態を確認します。
     """
-    return {"status": "ok"}
+    return {"status": "healthy"}
 
 @app.get("/")
 async def index():

--- a/backend/services/graph.py
+++ b/backend/services/graph.py
@@ -2,7 +2,8 @@ import networkx as nx
 
 class GraphService:
     def __init__(self):
-        pass
+        # Initialize an empty graph instance for later use
+        self.graph = nx.Graph()
 
     async def analyze(self, data):
         # ダミー実装のため、与えられたデータをそのまま返す


### PR DESCRIPTION
## Summary
- initialize internal NetworkX graph in `GraphService`
- update `/health` route to return a `healthy` status
- keep `/api/health` behaviour unchanged

## Testing
- `pytest backend/tests/integration/test_api.py::test_health_check -q`
- `PYTHONPATH=backend pytest backend/tests -k 'not e2e' -q` *(fails: CrawlerService.__init__() got an unexpected keyword argument 'firecrawl_api_key')*

------
https://chatgpt.com/codex/tasks/task_e_683f577077c08325ad599b994f93b150