### PR TITLE
Add OpenAI option and langgraph support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # API Keys
 GOOGLE_AISTUDIO_API_KEY=your_gemini_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
+# gemini or openai
+AI_PROVIDER=gemini
 FIRECRAWL_API_KEY=your_firecrawl_api_key_here
 GOOGLE_API_KEY=your_google_api_key_here
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ web-deep-research/
 ```
 # API Keys
 GOOGLE_AISTUDIO_API_KEY=your_gemini_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
+# gemini or openai
+AI_PROVIDER=gemini
 
 # Backend Settings
 BACKEND_PORT=8002
@@ -111,6 +114,7 @@ NEXT_PUBLIC_API_URL=http://localhost:8002
 ```
 NEXT_PUBLIC_API_URL=http://localhost:8002
 NODE_ENV=development
+AI_PROVIDER=gemini
 ```
 
 ### インストール
@@ -205,6 +209,10 @@ npm install --force
 ### Gemini APIのエラー
 
 Gemini APIに関するエラーが発生した場合は、`.env`ファイルの`GOOGLE_AISTUDIO_API_KEY`が正しく設定されていることを確認してください。
+
+### OpenAI APIのエラー
+
+OpenAIを使用する場合は、`.env`の`OPENAI_API_KEY`と`AI_PROVIDER=openai`が設定されているか確認してください。
 
 ## ライセンス
 

--- a/backend/app/api/routes/research.py
+++ b/backend/app/api/routes/research.py
@@ -2,7 +2,9 @@ from fastapi import APIRouter, HTTPException
 from typing import Dict, Any
 from pydantic import BaseModel
 from app.services.crawler_service import CrawlerService  # ウェブクロール処理用
-from app.services.gemini_service import GeminiService    # Geminiによるテキスト分析用
+from app.services.openai_service import OpenAIService  # for openai
+from app.services.gemini_service import GeminiService
+import os
 from app.services.googleai_service import GoogleAIService  # Google AIによる追加インサイト取得用
 from app.services.graph_service import GraphService        # ナレッジグラフ生成用
 
@@ -13,7 +15,7 @@ router = APIRouter()
 
 # サービスのインスタンス化
 crawler_service = CrawlerService()
-gemini_service = GeminiService()
+gemini_service = OpenAIService() if os.getenv("AI_PROVIDER") == "openai" else GeminiService()
 graph_service = GraphService()
 googleai_service = GoogleAIService()
 

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 from typing import Generator
 from config.settings import get_settings
 from services.crawler import CrawlerService
-from services.gemini import GeminiService
+from services import get_ai_service
 from services.graph import GraphService
 
 @lru_cache()
@@ -18,14 +18,10 @@ def get_crawler_service() -> CrawlerService:
     )
 
 @lru_cache()
-def get_gemini_service() -> GeminiService:
-    """
-    Geminiサービスのインスタンスを取得します。
-    """
-    settings = get_settings()
-    return GeminiService(
-        api_key=settings.GOOGLE_AISTUDIO_API_KEY
-    )
+def get_gemini_service():
+    """Get AI service based on AI_PROVIDER"""
+    get_settings()  # ensure env loaded
+    return get_ai_service()
 
 @lru_cache()
 def get_graph_service() -> GraphService:

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 
 # サービスのインポート
 from backend.services.crawler import CrawlerService, SearchResult
-from backend.services.gemini import GeminiService
+from backend.services import get_ai_service
 from backend.services.graph import GraphService
 from backend.services.cot_deepresearch import CoTDeepResearchService
 
@@ -79,7 +79,7 @@ class SearchResponse(BaseModel):
 
 # サービスのインスタンス
 crawler_service = CrawlerService()
-gemini_service = GeminiService()
+gemini_service = get_ai_service()
 graph_service = GraphService()
 cot_service = CoTDeepResearchService()
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,9 @@ langchain>=0.1.0,<0.4.0
 langchain-core>=0.1.16,<0.4.0
 langchain-community>=0.0.14,<0.4.0
 google-generativeai>=0.3.1,<0.4.0
+langchain-openai>=0.3.0
+openai>=1.0.0
+langgraph>=0.0.16
 
 # Data Processing
 networkx==3.2.1

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,7 +1,18 @@
 from .orchestrator import OrchestratorService
 from .gemini import GeminiService
+from .openai_service import OpenAIService
+import os
 from .graph import GraphService
 from .crawler import CrawlerService
 from .cot_deepresearch import CoTDeepResearchService
 
-__all__ = ['OrchestratorService', 'GeminiService', 'GraphService', 'CrawlerService', 'CoTDeepResearchService'] 
+def get_ai_service():
+    provider = os.getenv("AI_PROVIDER", "gemini").lower()
+    if provider == "openai":
+        return OpenAIService()
+    return GeminiService()
+
+__all__ = [
+    'OrchestratorService', 'GeminiService', 'OpenAIService',
+    'GraphService', 'CrawlerService', 'CoTDeepResearchService', 'get_ai_service'
+]

--- a/backend/services/cot_deepresearch.py
+++ b/backend/services/cot_deepresearch.py
@@ -12,6 +12,7 @@ if root_dir not in sys.path:
 
 # バックエンドサービスのインポート
 from scripts.cot_deepresearch import CoTDeepResearch
+from backend.services.langgraph_utils import generate_graph_from_text
 
 class CoTDeepResearchService:
     """
@@ -51,11 +52,17 @@ class CoTDeepResearchService:
         try:
             # 基本クラスのexecuteメソッドを呼び出す
             result = await self.cot_deepresearch.execute(query, max_pages, depth)
-            
+
             # 言語情報を追加
             if "metadata" in result:
                 result["metadata"]["language"] = language
-            
+
+            # 生成した分析からLangGraphでグラフ生成を試みる
+            analysis_text = result.get("analysis", "")
+            graph = generate_graph_from_text(str(analysis_text))
+            if graph is not None:
+                result["langgraph"] = graph
+
             return result
             
         except Exception as e:

--- a/backend/services/langgraph_utils.py
+++ b/backend/services/langgraph_utils.py
@@ -1,0 +1,20 @@
+import logging
+
+try:
+    from langgraph import Graph
+except Exception:  # pragma: no cover - library optional
+    Graph = None
+
+logger = logging.getLogger(__name__)
+
+def generate_graph_from_text(text: str):
+    """Generate a knowledge graph using langgraph if available."""
+    if Graph is None:
+        logger.warning("langgraph package not installed; skipping graph generation")
+        return None
+    try:
+        g = Graph({})
+        return g.query({"queryText": text})
+    except Exception as e:  # pragma: no cover - best effort
+        logger.error("LangGraph generation failed: %s", e)
+        return None

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -1,0 +1,40 @@
+import os
+import logging
+from typing import List, Dict, Any
+
+from langchain.chains import LLMChain
+from langchain.prompts import PromptTemplate
+from langchain_openai import ChatOpenAI
+
+class OpenAIService:
+    """OpenAI API based analysis service"""
+
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("OPENAI_API_KEY environment variable is required")
+        model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+        self.llm = ChatOpenAI(openai_api_key=self.api_key, model_name=model)
+
+        self.analysis_prompt = PromptTemplate(
+            input_variables=["results"],
+            template="""以下の検索結果を詳細に分析してください:\n\n{results}\n"""
+        )
+        self.analysis_chain = LLMChain(llm=self.llm, prompt=self.analysis_prompt)
+
+    async def analyze(self, results: List[Dict[str, Any]] | str) -> Dict[str, Any]:
+        try:
+            if isinstance(results, list):
+                text = "\n\n".join([
+                    f"タイトル: {r.get('title','')}\nURL: {r.get('url','')}\n内容: {r.get('content','')}"
+                    for r in results
+                ])
+            else:
+                text = str(results)
+
+            analysis_result = await self.analysis_chain.arun(results=text)
+            return {"raw_analysis": analysis_result}
+        except Exception as e:
+            self.logger.error(f"OpenAI analysis failed: {e}")
+            return {"error": str(e)}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,7 @@
 # API Keys
 GOOGLE_AISTUDIO_API_KEY=your_gemini_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
+AI_PROVIDER=gemini
 FIRECRAWL_API_KEY=your_firecrawl_api_key_here
 GOOGLE_API_KEY=your_google_api_key_here
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,9 @@ nest-asyncio>=1.5.6
 google-generativeai>=0.3.0
 langchain>=0.0.267
 langchain-community>=0.0.10
+langchain-openai==0.3.19
+openai>=1.0.0
+langgraph==0.0.16
 
 # ウェブクローリング
 selenium>=4.10.0

--- a/scripts/cot_deepresearch.py
+++ b/scripts/cot_deepresearch.py
@@ -14,7 +14,7 @@ import nest_asyncio
 
 # バックエンドサービスのインポート
 from backend.services.crawler import CrawlerService
-from backend.services.gemini import GeminiService
+from backend.services import get_ai_service
 
 # 非同期処理の設定
 nest_asyncio.apply()
@@ -54,7 +54,7 @@ class CoTDeepResearch:
             
             # Chain-of-Thought推論の実行
             self.logger.info('Chain-of-Thought推論を開始します。')
-            gemini = GeminiService()
+            gemini = get_ai_service()
             
             # CoTプロンプトの作成
             prompt = self._create_cot_prompt(query, combined_text, depth)

--- a/scripts/deepresearch.py
+++ b/scripts/deepresearch.py
@@ -33,7 +33,7 @@ import asyncio
 
 # 依存バックエンドサービスのインポート
 from backend.services.crawler import CrawlerService
-from backend.services.gemini import GeminiService
+from backend.services import get_ai_service
 
 # 非同期処理の設定
 nest_asyncio.apply()
@@ -142,7 +142,7 @@ class DeepResearch:
             combined_text += "\n"
 
         self.logger.info('Chain-of-Thought推論を開始します。')
-        gemini = GeminiService()
+        gemini = get_ai_service()
         prompt = (
             "# Chain-of-Thought Deep Research\n\n"
             "以下の幅広いウェブ検索結果に基づいて、詳細な分析と仮説検証を行ってください。\n\n"


### PR DESCRIPTION
## Summary
- allow using `OPENAI_API_KEY` and new `AI_PROVIDER` setting
- add OpenAI service and factory to select LLM
- generate graphs with langgraph when available
- document new environment variables
- update requirements for langchain-openai and langgraph

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_683f590c30b08325983d4e621cc13a54